### PR TITLE
Escape pipe character in Markdown table: replace "C|" with "C\|"

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Examples of accepted inputs:
 | `"6/8"` | Compound duple |
 | `"2/2"` | Alla breve |
 | `"common"` or `"C"` | Common time symbol |
-| `"cut"` or `"C|"` | Cut time symbol |
+| `"cut"` or `"C\|"` | Cut time symbol |
 
 ```typ
 #melody(music: "c4 d e f", time: "common")


### PR DESCRIPTION
Escape pipe character in Markdown table: replace "C|" with "C\|".
- Reason: '|' is a column delimiter in Markdown tables and must be escaped to render literal pipe.
- Change: substituted occurrences of "C|" with "C\|".