### PR TITLE
Fix incorrect behaviour when rendering ending lines where notes have manual whitespace gaps

### DIFF
--- a/tests/test-render-edge-cases.typ
+++ b/tests/test-render-edge-cases.typ
@@ -418,3 +418,15 @@ This document provides a series of tests to verify the rendering of edge cases i
     ),
   ),
 )
+
+#v(1cm)
+
+== Test 22: First Ending with Whitespace Gaps Across Measures
+
+#melody(
+  key: "G",
+  time: "3/4",
+  clef: "treble",
+  staff-size: 1.75mm,
+  music: "c4.d8  e8f|ga  bc'  d'c'|end{1.: b4a8g  fe|d2  c8g}|",
+)

--- a/wasm/src/layout.rs
+++ b/wasm/src/layout.rs
@@ -1728,7 +1728,7 @@ mod tests {
     }
 
     fn gap(amount: i32) -> Event {
-        Event::Gap(Gap { amount })
+        Event::Gap(Gap::new(amount))
     }
 
     fn mark_tuplet(event: &mut Event, in_time_of: f64, number: i32, count: i32) {

--- a/wasm/src/parser.rs
+++ b/wasm/src/parser.rs
@@ -1088,9 +1088,7 @@ impl<'a> Parser<'a> {
                     && next != Some(b'\n')
                     && next != Some(b'|')
                 {
-                    self.events.push(Event::Gap(Gap {
-                        amount: (run_len - 1) as i32,
-                    }));
+                    self.events.push(Event::Gap(Gap::new((run_len - 1) as i32)));
                 }
                 continue;
             }
@@ -1847,6 +1845,16 @@ impl<'a> Parser<'a> {
                             t.ending = l;
                             t.ending_start = is_first;
                             t.ending_end = is_last;
+                        }
+                        Event::KeySig(k) => {
+                            k.ending = l;
+                            k.ending_start = is_first;
+                            k.ending_end = is_last;
+                        }
+                        Event::Gap(g) => {
+                            g.ending = l;
+                            g.ending_start = is_first;
+                            g.ending_end = is_last;
                         }
                         Event::Spacer(s) => {
                             s.ending = l;

--- a/wasm/src/renderer.rs
+++ b/wasm/src/renderer.rs
@@ -4939,14 +4939,14 @@ mod beam_tests {
         let items = vec![
             laid_out_item(eighth_note("c")),
             laid_out_item(eighth_note("d")),
-            laid_out_item(Event::Gap(Gap { amount: 1 })),
+            laid_out_item(Event::Gap(Gap::new(1))),
             laid_out_item(eighth_note("e")),
             laid_out_item(eighth_note("f")),
-            laid_out_item(Event::Gap(Gap { amount: 1 })),
+            laid_out_item(Event::Gap(Gap::new(1))),
             laid_out_item(eighth_note("g")),
-            laid_out_item(Event::Gap(Gap { amount: 1 })),
+            laid_out_item(Event::Gap(Gap::new(1))),
             laid_out_item(eighth_note("a")),
-            laid_out_item(Event::Gap(Gap { amount: 1 })),
+            laid_out_item(Event::Gap(Gap::new(1))),
             laid_out_item(eighth_note("b")),
             laid_out_item(eighth_note("c")),
         ];

--- a/wasm/src/types.rs
+++ b/wasm/src/types.rs
@@ -220,11 +220,34 @@ pub struct TimeSig {
 pub struct KeySig {
     pub key: String,
     pub mode: String,
+    #[serde(default)]
+    pub ending: Option<String>,
+    #[serde(default)]
+    pub ending_start: bool,
+    #[serde(default)]
+    pub ending_end: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Gap {
     pub amount: i32,
+    #[serde(default)]
+    pub ending: Option<String>,
+    #[serde(default)]
+    pub ending_start: bool,
+    #[serde(default)]
+    pub ending_end: bool,
+}
+
+impl Gap {
+    pub fn new(amount: i32) -> Self {
+        Self {
+            amount,
+            ending: None,
+            ending_start: false,
+            ending_end: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -513,6 +536,8 @@ impl Event {
             Event::Barline(b) => b.ending.as_deref(),
             Event::Clef(cl) => cl.ending.as_deref(),
             Event::TimeSig(t) => t.ending.as_deref(),
+            Event::KeySig(k) => k.ending.as_deref(),
+            Event::Gap(g) => g.ending.as_deref(),
             Event::Spacer(s) => s.ending.as_deref(),
             _ => None,
         }
@@ -525,6 +550,8 @@ impl Event {
             Event::Barline(b) => b.ending_start,
             Event::Clef(cl) => cl.ending_start,
             Event::TimeSig(t) => t.ending_start,
+            Event::KeySig(k) => k.ending_start,
+            Event::Gap(g) => g.ending_start,
             Event::Spacer(s) => s.ending_start,
             _ => false,
         }
@@ -537,6 +564,8 @@ impl Event {
             Event::Barline(b) => b.ending_end,
             Event::Clef(cl) => cl.ending_end,
             Event::TimeSig(t) => t.ending_end,
+            Event::KeySig(k) => k.ending_end,
+            Event::Gap(g) => g.ending_end,
             Event::Spacer(s) => s.ending_end,
             _ => false,
         }


### PR DESCRIPTION
In sheet music input, manual whitespace gaps between notes to control beaming (e.g. `b8a  gf`) generate Event::Gap events in the event stream. Previously, Event::Gap (and Event::KeySig) lacked ending metadata fields (ending, ending_start, ending_end), causing close_ending to skip setting ending attributes on gap events during parsing.

When render_endings scanned items on a system, encountering an Event::Gap inside an ending resulted in item.event.ending() returning None. This prematurely severed the ending block into separate subgroups. The subsequent subgroup lacked ending_start = true, causing render_endings to fall back to opening_barline_x as the left coordinate, which drew an ending bracket line stretching all the way across from the far left margin of the system.

This commit fixes the issue by:
1. Adding ending, ending_start, and ending_end fields to Gap and KeySig structs.
2. Updating Event::ending(), ending_start(), and ending_end() getters for Gap and KeySig.
3. Updating close_ending() in parser to propagate ending metadata across Gap and KeySig events.
4. Adding Test 22 to tests/test-render-edge-cases.typ to verify ending brackets with whitespace gaps.